### PR TITLE
ci: adiciona Dockerfile configurado com xvfb para interface grafica

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y \
+    python3-tk \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . .
+
+CMD ["xvfb-run", "-a", "python", "main.py"]


### PR DESCRIPTION
Criação do Dockerfile utilizando xvfb para suportar a interface gráfica do Tkinter no contêiner, cumprindo as exigências de conteinerização do projeto.